### PR TITLE
fix(back-presses): back pressed functionality on mainactivity is fixed

### DIFF
--- a/app/src/main/java/com/plivo/plivosimplequickstart/MainActivity.java
+++ b/app/src/main/java/com/plivo/plivosimplequickstart/MainActivity.java
@@ -52,6 +52,7 @@ import static com.plivo.plivosimplequickstart.Utils.stopVibrating;
 
 public class MainActivity extends AppCompatActivity implements PlivoBackEnd.BackendListener {
     private static final int PERMISSIONS_REQUEST_CODE = 21;
+    private static final String TAG = MainActivity.class.getName();
 
     private Timer callTimer;
 
@@ -68,6 +69,7 @@ public class MainActivity extends AppCompatActivity implements PlivoBackEnd.Back
     Outgoing outgoing;
     boolean isKeyboardOpen = false;
     String keypadData = "";
+    boolean isBackPressed = false;
 
     public static boolean isInstantiated = false;
 
@@ -88,6 +90,21 @@ public class MainActivity extends AppCompatActivity implements PlivoBackEnd.Back
             }
         } else {
             init();
+        }
+
+    }
+
+    @Override
+    public void onBackPressed() {
+        Log.d(TAG, "onBackPressed Called");
+        if (isBackPressed) {
+            return;
+        }
+        if (outgoing == null && Utils.getIncoming() == null) {
+            isBackPressed = true;
+            logout();
+            isBackPressed = false;
+            super.onBackPressed();
         }
 
     }
@@ -253,7 +270,7 @@ public class MainActivity extends AppCompatActivity implements PlivoBackEnd.Back
             case REJECTED:
             case INVALID:
                 cancelTimer();
-                outgoing = null;
+                this.outgoing = null;
                 setContentView(R.layout.activity_main);
                 updateUI(STATE.IDLE, null);
                 break;
@@ -293,9 +310,11 @@ public class MainActivity extends AppCompatActivity implements PlivoBackEnd.Back
                 removeNotification(Constants.NOTIFICATION_ID);
                 setContentView(R.layout.activity_main);
                 updateUI(STATE.IDLE, null);
+                Utils.setIncoming(null);
                 break;
             case REJECTED:
                 removeNotification(Constants.NOTIFICATION_ID);
+                Utils.setIncoming(null);
                 break;
         }
     }


### PR DESCRIPTION
1. When the user presses back button on the call screen, nothing will happen. Back button functionality has been disabled on that screen.
2. When the user presses the back button on the home screen, the user will be unregistered first and then navigate back to the login screen.